### PR TITLE
Scheduler para remover pagamentos pendentes

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,7 +1,15 @@
 <?php
 
+use App\Enums\Payment\PaymentStatusEnum;
+use App\Models\Purchase;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+
+Artisan::command('purchases:delete', function() {
+    Purchase::where('created_at', '<=', now()->subDays(1))
+        ->where('status', PaymentStatusEnum::PENDING->value)
+        ->delete();
+})->purpose('Delete pending purchases older than 1 day')->daily();
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());


### PR DESCRIPTION
Com a utilização do serviço Laravel Scheduler foi possível definir uma tarefa agendata, através de um comando Artisan, para remover pagamentos pendentes antigos