### PR TITLE
controle de estoque para compras rejeitadas

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,17 +1,38 @@
 <?php
 
 use App\Enums\Payment\PaymentStatusEnum;
+use App\Models\Product;
 use App\Models\Purchase;
-use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 
-Artisan::command('purchases:delete', function() {
+Artisan::command('purchases:reject', function () {
     Purchase::where('created_at', '<=', now()->subDays(1))
         ->where('status', PaymentStatusEnum::PENDING->value)
-        ->orWhere('status', PaymentStatusEnum::REJECTED->value)
-        ->delete();
-})->purpose('Delete pending or rejected purchases older than 1 day')->daily();
+        ->update([
+            'status' => PaymentStatusEnum::REJECTED->value
+        ]);
+})->purpose('Reject pending purchases older than 1 day')->daily();
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote')->hourly();
+Artisan::command('products:reset-stock', function () {
+    $rejectedPurchases = Purchase::select('product_id', DB::raw('SUM(quantity) as total_quantity'))
+        ->where('status', PaymentStatusEnum::REJECTED->value)
+        ->where('quantity', '>', 0)
+        ->groupBy('product_id')
+        ->get();
+
+    foreach ($rejectedPurchases as $purchase) {
+        Product::where('id', $purchase->product_id)
+            ->update(['stock' => DB::raw('stock + ' . $purchase->total_quantity)]);
+    }
+
+    Purchase::where('status', PaymentStatusEnum::REJECTED->value)
+        ->where('quantity', '>', 0)
+        ->update(['quantity' => 0]);
+})->purpose('Reset inventory for rejected purchase products')->daily();
+
+Artisan::command('purchases:delete', function () {
+    Purchase::where('quantity', 0)
+        ->where('status', PaymentStatusEnum::REJECTED->value)
+        ->delete();
+})->purpose('Delete rejected purchases daily')->daily();


### PR DESCRIPTION
Definindo comandos Artisan que são executados periodicamente pelo Laravel Schedule a fim de definir compras pendentes antigas como rejeitadas, devolver a quantidade de produtos comprados ao estoque e apagar essas compras